### PR TITLE
feature/#6 카카오맵 Home 페이지에 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
-*.env
+.env

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+.env

--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
-.env
+*.env

--- a/.prettierrc
+++ b/.prettierrc
@@ -5,5 +5,6 @@
   "semi": true,
   "singleQuote": true,
   "bracketSpacing": true,
-  "trailingComma": "none"
+  "trailingComma": "none",
+  "endOfLine": "auto"
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "lucide-react": "^0.476.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-kakao-maps-sdk": "^1.1.27",
     "react-router-dom": "^7.2.0",
     "tailwind-merge": "^3.0.2",
     "tailwindcss": "^4.0.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       react-dom:
         specifier: ^19.0.0
         version: 19.0.0(react@19.0.0)
+      react-kakao-maps-sdk:
+        specifier: ^1.1.27
+        version: 1.1.27(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react-router-dom:
         specifier: ^7.2.0
         version: 7.2.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -151,6 +154,10 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+
+  '@babel/runtime@7.26.9':
+    resolution: {integrity: sha512-aA63XwOkcl4xxQa3HjPMqOP6LiK0ZDv3mUPYEFXkpHbaFjtGggE1A61FjFzJnB+p7/oy2gA8E+rcBNl/zC1tMg==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/template@7.26.9':
     resolution: {integrity: sha512-qyRplbeIpNZhmzOysF/wFMuP9sctmh2cFzRAZOn1YapxBsE1i9bJIY586R/WBLfLcmcBlM8ROBiQURnnNy+zfA==}
@@ -1175,6 +1182,9 @@ packages:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
 
+  kakao.maps.d.ts@0.1.40:
+    resolution: {integrity: sha512-nX69MB1ok04epe3OqS+/tEeWBbU31GSQbvDPJmQRRltzzqn6t4jBsO5v1nzalUjCKzwcH2CptOc767NZ7Hbu3g==}
+
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
@@ -1375,6 +1385,12 @@ packages:
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
+  react-kakao-maps-sdk@1.1.27:
+    resolution: {integrity: sha512-1EwYkYsjTDRFqysKStDasFMrFTXcLx2AyRlqMoWD7ONWhRqpjx9M874hkhEEHrnypP2eSIhhDLe0EiSKp3bd2Q==}
+    peerDependencies:
+      react: ^16.8 || ^17 || ^18
+      react-dom: ^16.8 || ^17 || ^18
+
   react-refresh@0.14.2:
     resolution: {integrity: sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==}
     engines: {node: '>=0.10.0'}
@@ -1403,6 +1419,9 @@ packages:
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
     engines: {node: '>= 0.4'}
+
+  regenerator-runtime@0.14.1:
+    resolution: {integrity: sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==}
 
   regexp.prototype.flags@1.5.4:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
@@ -1772,6 +1791,10 @@ snapshots:
     dependencies:
       '@babel/core': 7.26.9
       '@babel/helper-plugin-utils': 7.26.5
+
+  '@babel/runtime@7.26.9':
+    dependencies:
+      regenerator-runtime: 0.14.1
 
   '@babel/template@7.26.9':
     dependencies:
@@ -2860,6 +2883,8 @@ snapshots:
       object.assign: 4.1.7
       object.values: 1.2.1
 
+  kakao.maps.d.ts@0.1.40: {}
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
@@ -3041,6 +3066,13 @@ snapshots:
 
   react-is@16.13.1: {}
 
+  react-kakao-maps-sdk@1.1.27(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
+    dependencies:
+      '@babel/runtime': 7.26.9
+      kakao.maps.d.ts: 0.1.40
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+
   react-refresh@0.14.2: {}
 
   react-router-dom@7.2.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
@@ -3071,6 +3103,8 @@ snapshots:
       get-intrinsic: 1.3.0
       get-proto: 1.0.1
       which-builtin-type: 1.2.1
+
+  regenerator-runtime@0.14.1: {}
 
   regexp.prototype.flags@1.5.4:
     dependencies:

--- a/src/config/router.jsx
+++ b/src/config/router.jsx
@@ -1,3 +1,4 @@
+import Home from '@/pages/home';
 import RootLayout from '@layouts/root-layout';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 
@@ -5,8 +6,8 @@ export default function Router() {
   return (
     <BrowserRouter>
       <Routes>
-        <Route path="/" element={<RootLayout />}>
-          <Route path="/" element={<>home</>} />
+        <Route element={<RootLayout />}>
+          <Route path="/" element={<Home />} />
         </Route>
       </Routes>
     </BrowserRouter>

--- a/src/constants/app-key.js
+++ b/src/constants/app-key.js
@@ -1,0 +1,1 @@
+export const KAKAO_MAP_API_KEY = import.meta.env.VITE_KAKAO_MAP_API_KEY;

--- a/src/constants/map-scale.js
+++ b/src/constants/map-scale.js
@@ -1,0 +1,14 @@
+export const MAP_SCALE_20M = 1;
+export const MAP_SCALE_30M = 2;
+export const MAP_SCALE_50M = 3;
+export const MAP_SCALE_100M = 4;
+export const MAP_SCALE_250M = 5;
+export const MAP_SCALE_500M = 6;
+export const MAP_SCALE_1KM = 7;
+export const MAP_SCALE_2KM = 8;
+export const MAP_SCALE_4KM = 9;
+export const MAP_SCALE_8KM = 10;
+export const MAP_SCALE_16KM = 11;
+export const MAP_SCALE_32KM = 12;
+export const MAP_SCALE_64KM = 13;
+export const MAP_SCALE_128KM = 14;

--- a/src/lib/apis/map.api.js
+++ b/src/lib/apis/map.api.js
@@ -1,9 +1,10 @@
+import { KAKAO_MAP_API_KEY } from '@/constants/app-key';
 import { useKakaoLoader } from 'react-kakao-maps-sdk';
 
 export function useKakaoMapQuery() {
   const [loading, error] = useKakaoLoader({
-    appkey: import.meta.env.VITE_KAKAO_MAP_API_KEY // 환경 변수에서 API 키 가져오기
+    appkey: KAKAO_MAP_API_KEY // 환경 변수에서 API 키 가져오기
   });
 
-  return { KakaoMapLoading: loading, KakaoMapError: error };
+  return { kakaoMapLoading: loading, kakaoMapError: error };
 }

--- a/src/lib/apis/map.api.js
+++ b/src/lib/apis/map.api.js
@@ -1,9 +1,9 @@
 import { useKakaoLoader } from 'react-kakao-maps-sdk';
 
 export function useKakaoMapQuery() {
-  const [KakaoMapLoading, KakaoMapError] = useKakaoLoader({
+  const [loading, error] = useKakaoLoader({
     appkey: import.meta.env.VITE_KAKAO_MAP_API_KEY // 환경 변수에서 API 키 가져오기
   });
 
-  return { KakaoMapLoading, KakaoMapError };
+  return { KakaoMapLoading: loading, KakaoMapError: error };
 }

--- a/src/lib/apis/map.api.js
+++ b/src/lib/apis/map.api.js
@@ -3,7 +3,7 @@ import { useKakaoLoader } from 'react-kakao-maps-sdk';
 
 export function useKakaoMapQuery() {
   const [loading, error] = useKakaoLoader({
-    appkey: KAKAO_MAP_API_KEY // 환경 변수에서 API 키 가져오기
+    appkey: KAKAO_MAP_API_KEY
   });
 
   return { kakaoMapLoading: loading, kakaoMapError: error };

--- a/src/lib/apis/map.api.js
+++ b/src/lib/apis/map.api.js
@@ -1,0 +1,9 @@
+import { useKakaoLoader } from 'react-kakao-maps-sdk';
+
+export function useKakaoMapQuery() {
+  const [KakaoMapLoading, KakaoMapError] = useKakaoLoader({
+    appkey: import.meta.env.VITE_KAKAO_MAP_API_KEY // 환경 변수에서 API 키 가져오기
+  });
+
+  return { KakaoMapLoading, KakaoMapError };
+}

--- a/src/pages/home.jsx
+++ b/src/pages/home.jsx
@@ -1,0 +1,26 @@
+import { useKakaoMapQuery } from '@/lib/apis/map.api';
+import { Map } from 'react-kakao-maps-sdk';
+
+export default function Home() {
+  const { KakaoMapLoading, KakaoMapError } = useKakaoMapQuery();
+
+  // 로딩 중일 때 화면에 로딩 메시지 표시
+  if (KakaoMapLoading) return <div>Loading...</div>;
+
+  // 에러가 있을 경우 에러 메시지 표시
+  if (KakaoMapError) return <div>Error loading map: {KakaoMapError.message}</div>;
+
+  return (
+    <Map
+      center={{
+        lat: 33.450701,
+        lng: 126.570667
+      }}
+      style={{
+        width: '100%',
+        height: '450px'
+      }}
+      level={3}
+    />
+  );
+}

--- a/src/pages/home.jsx
+++ b/src/pages/home.jsx
@@ -1,3 +1,4 @@
+import { MAP_SCALE_50M } from '@/constants/map-scale';
 import { useKakaoMapQuery } from '@/lib/apis/map.api';
 import { Map } from 'react-kakao-maps-sdk';
 
@@ -15,7 +16,7 @@ export default function Home() {
         lng: 126.570667
       }}
       className="w-full h-full"
-      level={3}
+      level={MAP_SCALE_50M}
     />
   );
 }

--- a/src/pages/home.jsx
+++ b/src/pages/home.jsx
@@ -2,13 +2,11 @@ import { useKakaoMapQuery } from '@/lib/apis/map.api';
 import { Map } from 'react-kakao-maps-sdk';
 
 export default function Home() {
-  const { KakaoMapLoading, KakaoMapError } = useKakaoMapQuery();
+  const { kakaoMapLoading, kakaoMapError } = useKakaoMapQuery();
 
-  // 로딩 중일 때 화면에 로딩 메시지 표시
-  if (KakaoMapLoading) return <div>로딩중입니다...</div>;
+  if (kakaoMapLoading) return <div>로딩중입니다...</div>;
 
-  // 에러가 있을 경우 에러 메시지 표시
-  if (KakaoMapError) return <div>에러입니다...{KakaoMapError.message}</div>;
+  if (kakaoMapError) return <div>에러입니다...{kakaoMapError.message}</div>;
 
   return (
     <Map
@@ -16,10 +14,7 @@ export default function Home() {
         lat: 33.450701,
         lng: 126.570667
       }}
-      style={{
-        width: '100%',
-        height: '100%'
-      }}
+      className="w-full h-full"
       level={3}
     />
   );

--- a/src/pages/home.jsx
+++ b/src/pages/home.jsx
@@ -18,7 +18,7 @@ export default function Home() {
       }}
       style={{
         width: '100%',
-        height: '450px'
+        height: '100%'
       }}
       level={3}
     />

--- a/src/pages/home.jsx
+++ b/src/pages/home.jsx
@@ -5,10 +5,10 @@ export default function Home() {
   const { KakaoMapLoading, KakaoMapError } = useKakaoMapQuery();
 
   // 로딩 중일 때 화면에 로딩 메시지 표시
-  if (KakaoMapLoading) return <div>Loading...</div>;
+  if (KakaoMapLoading) return <div>로딩중입니다...</div>;
 
   // 에러가 있을 경우 에러 메시지 표시
-  if (KakaoMapError) return <div>Error loading map: {KakaoMapError.message}</div>;
+  if (KakaoMapError) return <div>에러입니다...{KakaoMapError.message}</div>;
 
   return (
     <Map


### PR DESCRIPTION
🔗 관련 이슈
관련 이슈: https://github.com/KIMgyeongmIN00/out-source-project/issues/6
📝 변경 사항
[설치]: react-kakao-maps-sdk 을 pnpm 으로 설치

[추가]: 카카오맵 API 키 환경변수 추가

[추가]: Home 컴포넌트 생성 및 지도 추가

[변경]: router.jsx에 Home Route 변경

📸 변경 후 (UI 변경이 있을 경우)
![image](https://github.com/user-attachments/assets/c65711f4-949a-4200-be39-67e7d45bcfa8)

🏷 참고 자료
<a href="https://react-kakao-maps-sdk.jaeseokim.dev/docs/intro/" target="_blank">Kakao 지도 Tutorial</a>
<a href="https://react-kakao-maps-sdk.jaeseokim.dev/docs/setup/withHook/" target="_blank">Hook을 이용하여 Kakao 지도 API 