### PR TITLE
Feature/#29 이전 일정 불러온 후 렌더링

### DIFF
--- a/src/components/features/profile/profile-form.jsx
+++ b/src/components/features/profile/profile-form.jsx
@@ -6,7 +6,7 @@ import useUpdateProfileMutation from '@/lib/hooks/use-update-profile-mutation';
 
 export default function ProfileForm() {
   const [editMode, setEditMode] = useState(false);
-  const [nickname, setNickname] = useState(user.nickname);
+  const [nickname, setNickname] = useState('');
 
   const user = useAuthStore((state) => state.user);
 

--- a/src/lib/hooks/use-get-all-plans-usequery.js
+++ b/src/lib/hooks/use-get-all-plans-usequery.js
@@ -1,0 +1,26 @@
+import { useQuery } from '@tanstack/react-query';
+import { supabase } from '../apis/supabase.api';
+import { useAuthStore } from '@/stores/auth.store';
+
+export default function useGetAllPlansQuery() {
+  const user = useAuthStore((state) => state.user);
+
+  async function getPlans() {
+    const { data, error } = await supabase.from('plans').select('*').eq('user_id', user.id);
+    if (error) {
+      console.error(error);
+    }
+    return data || [];
+  }
+
+  const {
+    data: plans,
+    isPending,
+    isError
+  } = useQuery({
+    queryKey: ['plans'],
+    queryFn: getPlans
+  });
+
+  return { plans, isPending, isError };
+}

--- a/src/pages/profile.jsx
+++ b/src/pages/profile.jsx
@@ -9,8 +9,18 @@ import {
   PaginationPrevious
 } from '@/components/ui/pagination';
 import ProfileForm from '@/components/features/profile/profile-form';
+import useGetAllPlansQuery from '@/lib/hooks/use-get-all-plans-usequery';
 
 export default function Profile() {
+  const { plans, isPending, isError } = useGetAllPlansQuery();
+
+  if (isPending) {
+    return <div>계획 불러오는 중...</div>;
+  }
+
+  if (isError) {
+    return <div>계획 불러오기 실패</div>;
+  }
   return (
     <div className="flex flex-col items-center gap-4 h-full">
       <section className="flex flex-row border-2 border-primary rounded-lg w-full h-30 p-4">
@@ -33,17 +43,24 @@ export default function Profile() {
           <div className="flex flex-col justify-center">
             <h3 className="mb-4">지난 일정</h3>
             <ul className="flex flex-row flex-wrap gap-4">
-              <li className="flex flex-col justify-between border-2 border-primary p-4 rounded-lg w-[356px] h-[130px]">
-                <p className="mb-1 font-semibold">누군가와의 약속</p>
-                <p className="flex items-center gap-1">
-                  <MdOutlineAccessTime />
-                  날짜
-                </p>
-                <p className="flex items-center gap-1">
-                  <MdOutlineLocationOn />
-                  장소 주소
-                </p>
-              </li>
+              {plans.map((plan) => {
+                return (
+                  <li
+                    key={plan.id}
+                    className="flex flex-col justify-between border-2 border-primary p-4 rounded-lg w-[356px] h-[130px]"
+                  >
+                    <p className="mb-1 font-semibold">{plan.title}</p>
+                    <p className="flex items-center gap-1">
+                      <MdOutlineAccessTime />
+                      {plan.date}
+                    </p>
+                    <p className="flex items-center gap-1">
+                      <MdOutlineLocationOn />
+                      {plan.address}
+                    </p>
+                  </li>
+                );
+              })}
             </ul>
           </div>
           <Pagination>


### PR DESCRIPTION
### 🔗 **관련 이슈**
- 관련 이슈: #29 
---

### 📝 **변경 사항**
<!-- 변경 사항을 간결하게 설명해주세요. -->
- supabase에 있는 로그인한 유저가 쓴 계획(제목, 작성 시간, 주소)을 렌더링
- profile페이지 접속할 때 useState 초기 값 에러 발생해 에러 수정
---

### 📸 **변경 후 (UI 변경이 있을 경우)**
자신이 쓴 일정을 렌더링한 모습입니다.

![스크린샷 2025-03-02 161423](https://github.com/user-attachments/assets/ffcd5148-2847-4aba-856e-5679e1746ccc)
---