### PR TITLE
Feature/#35 사이드바에 일정 표시

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,6 @@
-import Router from '@/config/router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import useAuthSubScriber from '@/lib/hooks/use-auth-subscriber';
+import Router from '@/config/router';
+import useAuthSubScriber from '@/lib/hooks/use-auth-subscriber.hook';
 
 const queryClient = new QueryClient();
 

--- a/src/components/layouts/sidebar/plan-card.jsx
+++ b/src/components/layouts/sidebar/plan-card.jsx
@@ -1,0 +1,21 @@
+import React, { forwardRef } from 'react';
+import { MdOutlineAccessTime, MdOutlineLocationOn } from 'react-icons/md';
+
+const PlanCard = forwardRef(({ plan }, ref) => {
+  return (
+    <li ref={ref} key={plan.id} className="p-2 mb-3 border border-primary rounded-sm">
+      <h5 className="font-semibold overflow-hidden text-ellipsis text-nowrap">{plan.title}</h5>
+      <p className="text-sm flex items-center gap-1">
+        <MdOutlineAccessTime className="mr-1" />
+        <span className="flex-1 overflow-hidden text-ellipsis text-nowrap">{plan.date}</span>
+      </p>
+      <p className="text-sm flex items-center gap-1">
+        <MdOutlineLocationOn className="mr-1" />
+        <span className="flex-1 overflow-hidden text-ellipsis text-nowrap">{plan.address}</span>
+      </p>
+    </li>
+  );
+});
+
+PlanCard.displayName = 'PlanCard';
+export default React.memo(PlanCard);

--- a/src/components/layouts/sidebar/plan-panel.jsx
+++ b/src/components/layouts/sidebar/plan-panel.jsx
@@ -1,63 +1,45 @@
-import { MdOutlineAccessTime, MdOutlineLocationOn } from 'react-icons/md';
+import { Fragment, useCallback, useRef } from 'react';
+import PlanCard from '@/components/layouts/sidebar/plan-card';
+import useGetUpcomingPlansQuery from '@/lib/hooks/use-get-upcoming-plans-query.hook';
 
 export default function PlanPanel({ id }) {
-  // TODO: 자신의 남은 일정을 가져오는 API 연결
-  const plans = getPlansById(id);
+  const { pages, fetchNextPage, hasNextPage, isFetchingNextPage } = useGetUpcomingPlansQuery(id);
+
+  const observerRef = useRef(null);
+  const lastPlanCardRef = useCallback(
+    (node) => {
+      if (observerRef.current) observerRef.current.disconnect();
+
+      observerRef.current = new IntersectionObserver((entries) => {
+        if (entries[0].isIntersecting && hasNextPage && !isFetchingNextPage) {
+          fetchNextPage();
+        }
+      });
+      if (node) observerRef.current.observe(node);
+    },
+    [hasNextPage, isFetchingNextPage, fetchNextPage]
+  );
 
   return (
     <section className="flex-1 flex flex-col overflow-hidden rounded-lg">
       <h3 className="font-bold text-xl mb-2">일정</h3>
-      {plans.length === 0 ? (
+      {!pages || pages.length === 0 ? (
         <p className="text-center py-4">일정이 없습니다!</p>
       ) : (
         <div className="flex-1 overflow-hidden bg-gradient-to-t from-primary/30 via-transparent via-20% to-transparent">
           <ul className="h-full overflow-y-scroll">
-            {plans.map((plan) => (
-              <li key={plan.id} className="p-2 mb-3 border border-primary rounded-sm">
-                <h5 className="font-semibold overflow-hidden text-ellipsis text-nowrap">{plan.title}</h5>
-                <p className="text-sm flex items-center gap-1">
-                  <MdOutlineAccessTime className="mr-1" />
-                  <span className="flex-1 overflow-hidden text-ellipsis text-nowrap">{plan.date}</span>
-                </p>
-                <p className="text-sm flex items-center gap-1">
-                  <MdOutlineLocationOn className="mr-1" />
-                  <span className="flex-1 overflow-hidden text-ellipsis text-nowrap">{plan.address}</span>
-                </p>
-              </li>
+            {pages.map((page, pageIdx) => (
+              <Fragment key={pageIdx}>
+                {page.plans.map((plan, idx) => {
+                  if (pageIdx === pages.length - 1 && idx === page.plans.length - 1)
+                    return <PlanCard key={plan.id} plan={plan} ref={lastPlanCardRef} />;
+                  return <PlanCard key={plan.id} plan={plan} />;
+                })}
+              </Fragment>
             ))}
           </ul>
         </div>
       )}
     </section>
   );
-}
-
-// TODO: 삭제 - API 연결전 ui를 띄우기 위한 mocks 데이터 입니다!
-function getPlansById() {
-  return [
-    {
-      id: crypto.randomUUID(),
-      title: '누군가와의 약속1',
-      address: '서울 영등포구 여의대로 108 더현대 서울',
-      date: '2025-08-22 12:00:00'
-    },
-    {
-      id: crypto.randomUUID(),
-      title: '누군가와의 약속2',
-      address: '서울 영등포구 여의대로 108 더현대 서울',
-      date: '2025-08-22 12:00:00'
-    },
-    {
-      id: crypto.randomUUID(),
-      title: '제몬을 길게 작성한 일정 내용입니다. 제목의 최대 길이를 정해두어야할까요?',
-      address: '서울 영등포구 여의대로 108 더현대 서울',
-      date: '2025-08-22 12:00:00'
-    },
-    {
-      id: crypto.randomUUID(),
-      title: '누군가와의 약속3',
-      address: '서울 영등포구 여의대로 108 더현대 서울',
-      date: '2025-08-22 12:00:00'
-    }
-  ];
 }

--- a/src/components/layouts/sidebar/sidebar.jsx
+++ b/src/components/layouts/sidebar/sidebar.jsx
@@ -2,6 +2,7 @@ import PlanPanel from '@/components/layouts/sidebar/plan-panel';
 import SignPanel from '@/components/layouts/sidebar/sign-panel';
 import UserPanel from '@/components/layouts/sidebar/user-panel';
 import { useAuthStore } from '@/stores/auth.store';
+import { Suspense } from 'react';
 
 export default function Sidebar() {
   const { isAuthenticated: isAuth, user } = useAuthStore();
@@ -10,7 +11,7 @@ export default function Sidebar() {
     <div className="w-[250px] h-full overflow-hidden flex flex-col gap-8 border border-primary rounded-2xl px-4 pt-8 pb-6">
       <img src="/logo.png" alt="로고 이미지" className=" w-full box-border px-6" />
       {isAuth ? <UserPanel user={user} /> : <SignPanel />}
-      {isAuth && <PlanPanel />}
+      <Suspense fallback={<div>Loading plans...</div>}>{isAuth && <PlanPanel id={user.id} />}</Suspense>
     </div>
   );
 }

--- a/src/constants/query-keys.js
+++ b/src/constants/query-keys.js
@@ -1,0 +1,3 @@
+export const QueryKeys = {
+  INFINITY_UPCOMING_PLANS: ['infinity-upcoming-plans']
+};

--- a/src/lib/apis/plan.api.js
+++ b/src/lib/apis/plan.api.js
@@ -1,5 +1,26 @@
-import axiosApi from "@api/axios.api";
+import { axiosApi } from '@api/axios.api';
 
+/**
+ * 현재 날짜 이후의 사용자 일정을 페이지네이션으로 조회합니다.
+ *
+ * @param {string} userId - 조회할 사용자의 UUID
+ * @param {number} [page=1] - 요청할 페이지 번호 (기본값: 1)
+ * @param {number} [limit=10] - 페이지당 가져올 일정 수 (기본값: 10)
+ * @returns {Promise<Object>} - 일정 데이터가 포함된 응답 객체
+ */
+export async function fetchUpcomingPlans(userId, page = 1, limit = 10) {
+  const currentDate = new Date().toISOString();
+  return await axiosApi.get('/plans', {
+    params: {
+      select: '*',
+      user_id: `eq.${userId}`,
+      date: `gte.${currentDate}`,
+      order: 'date.asc',
+      limit: limit,
+      offset: (page - 1) * limit
+    }
+  });
+}
 
 // 내 계획 갯수대로 가져오기 (무한 스크롤은 추가 로직으로 limit와 offset 알고리즘 구현 해야됩니다...)
 // limit => 얼만큼? , offset => 어디서 부터?
@@ -9,8 +30,8 @@ export async function fetchMyPlansLimit(myId, limit, offset) {
       select: '*',
       user_id: `eq.${myId}`,
       limit,
-      offset,
-    },
+      offset
+    }
   });
   return response;
 }
@@ -21,8 +42,8 @@ export async function fetchPlacePlan(address, myId) {
     params: {
       select: '*',
       address: `eq.${address}`,
-      user_id: `eq.${myId}`,
-    },
+      user_id: `eq.${myId}`
+    }
   });
   return response;
 }
@@ -32,8 +53,8 @@ export async function fetchSharePlan(planId) {
   const response = await axiosApi.get('plans', {
     params: {
       select: '*',
-      id: `eq.${planId}`,
-    },
+      id: `eq.${planId}`
+    }
   });
   return response;
 }
@@ -42,16 +63,16 @@ export async function fetchSharePlan(planId) {
 export async function createData(data) {
   const response = await axiosApi.post('plans', data);
   return response;
-};
+}
 
 // 계획 수정하기
 export async function updateData(id, data) {
   const response = await axiosApi.patch(`plans?id=eq.${id}`, data);
   return response;
-};
+}
 
 // 계획 삭제하기
 export async function deleteData(id) {
   const response = await axiosApi.delete(`plans?id=eq.${id}`);
   return response;
-};
+}

--- a/src/lib/hooks/use-auth-subscriber.hook.js
+++ b/src/lib/hooks/use-auth-subscriber.hook.js
@@ -3,24 +3,27 @@ import { supabase } from '@/lib/apis/supabase.api';
 import { useAuthStore } from '@/stores/auth.store';
 
 export default function useAuthSubScriber() {
+  const setUser = useAuthStore((state) => state.setUser);
+  const clearUser = useAuthStore((state) => state.clearUser);
+
   useEffect(() => {
-    const { data } = supabase.auth.onAuthStateChange(async (event, session) => {
-      if (event === 'SIGNED_IN' && session) {
-        useAuthStore.getState().setUser({
+    const { data } = supabase.auth.onAuthStateChange((_, session) => {
+      if (session) {
+        setUser({
           id: session.user.id,
           email: session.user.email,
           nickname: session.user.user_metadata.nickname,
           profileUrl: session.user.user_metadata.profile_url
         });
       } else {
-        useAuthStore.getState().clearUser();
+        clearUser();
       }
     });
 
     return () => {
       data.subscription.unsubscribe();
     };
-  }, []);
+  }, [setUser, clearUser]);
 
   return null;
 }

--- a/src/lib/hooks/use-get-upcoming-plans-query.hook.js
+++ b/src/lib/hooks/use-get-upcoming-plans-query.hook.js
@@ -12,8 +12,9 @@ export default function useGetUpcomingPlansQuery(userId, limit = 2) {
     queryKey: QueryKeys.INFINITY_UPCOMING_PLANS,
     queryFn: async ({ pageParam }) => {
       const response = await fetchUpcomingPlans(userId, pageParam, limit);
-      const plans = response.data.map(({ created_at, user_id, ...rest }) => ({
+      const plans = response.data.map(({ created_at, user_id, date, ...rest }) => ({
         ...rest,
+        date: date.replace('T', ' '),
         userId: user_id,
         createdAt: created_at
       }));

--- a/src/lib/hooks/use-get-upcoming-plans-query.hook.js
+++ b/src/lib/hooks/use-get-upcoming-plans-query.hook.js
@@ -1,0 +1,30 @@
+import { QueryKeys } from '@/constants/query-keys';
+import { fetchUpcomingPlans } from '@/lib/apis/plan.api';
+import { useSuspenseInfiniteQuery } from '@tanstack/react-query';
+
+export default function useGetUpcomingPlansQuery(userId, limit = 2) {
+  const {
+    data: { pages },
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage
+  } = useSuspenseInfiniteQuery({
+    queryKey: QueryKeys.INFINITY_UPCOMING_PLANS,
+    queryFn: async ({ pageParam }) => {
+      const response = await fetchUpcomingPlans(userId, pageParam, limit);
+      const plans = response.data.map(({ created_at, user_id, ...rest }) => ({
+        ...rest,
+        userId: user_id,
+        createdAt: created_at
+      }));
+
+      const hasMore = plans.length === limit;
+
+      return { plans, nextPage: hasMore ? pageParam + 1 : undefined };
+    },
+    initialPageParam: 1,
+    getNextPageParam: (lastPage) => lastPage.nextPage
+  });
+
+  return { pages, fetchNextPage, hasNextPage, isFetchingNextPage };
+}


### PR DESCRIPTION
### 🔗 **관련 이슈**
- close #35 

---

### 📝 **변경 사항**
<!-- 변경 사항을 간결하게 설명해주세요. -->
- ✨ 사이드 바에 남은 일정을 api를 통해 가져와 보여주도록 수정했습니다.
- 🛠 useSuspenseInfiniteQuery 를 사용하여 무한 스크롤을 적용했습니다.
- 🚀 suspense를 통해서 pending 상태를 관리하고 있습니다.

---

### 📸 **변경 후 (UI 변경이 있을 경우)**
![image](https://github.com/user-attachments/assets/37fc6d93-1fb2-4da8-9412-659c4d8c0700)


### 기타 사항
- query keys 적용 방식에 대해서 저희가 말을 하지 않았습니다.
- 제안 받은 query key를 적용하는 방법은 2가지가 있습니다.
#### 방법 1: 
```
// query-keys.js
export const QueryKeys = {
    INFINITY_UPCOMING_PLANS: ['infinity-upcoming-plans'],
    PLANS_PER_PAGE: ( page ) => ['plans', page] 
}

// use-~~~-query.js
export function useGetPlansPerPageQuery ( page ) {
    return useQuery({
        queryKey: QueryKeys.PLANS_PER_PAGE(page),
        ...
    });
} 
```

#### 방법 2: 
```
// query-keys.js
export const QueryKeys = {
    INFINITY_UPCOMING_PLANS: 'infinity-upcoming-plans'
    PLANS_PER_PAGE: 'plans' 
}

// use-~~~-query.js
export function useGetPlansPerPageQuery ( page ) {
    return useQuery({
        queryKey: [ QueryKeys.PLANS_PER_PAGE, page ],
        ...
    });
} 
```

1번째 방법은 query-keys 자체를 저장하는 방식이고, 2번째 방식은 키워드만 저장하는 방식이라고 생각됩니다.
일반 1번째 방법으로 구현하였는데요. 회의결과 방식이 변경되면, 수정하겠습니다!! 
